### PR TITLE
Map our custom RecommendationDetails fields to the same types as the generated RecommendationDetails

### DIFF
--- a/cmd/tidelift-sbom-vulnerability-reporter/main.go
+++ b/cmd/tidelift-sbom-vulnerability-reporter/main.go
@@ -20,9 +20,9 @@ import (
 type RecommendationDetails struct {
 	RealIssue             bool    `json:"real_issue"`
 	FalsePositiveReason   *string `json:"false_positive_reason"`
-	ImpactScore           int     `json:"impact_score"`
-	ImpactDescription     string  `json:"impact_description"`
-	WorkaroundAvailable   bool    `json:"workaround_available"`
+	ImpactScore           *int    `json:"impact_score"`
+	ImpactDescription     *string `json:"impact_description"`
+	WorkaroundAvailable   *bool   `json:"workaround_available"`
 	WorkaroundDescription *string `json:"workaround_description"`
 }
 
@@ -144,9 +144,9 @@ func writeVulnerabilitiesReport(outputFile string, purls []packageurl.PackageURL
 									r := RecommendationDetails{
 										RealIssue:             a.RecommendationDetails.RealIssue,
 										FalsePositiveReason:   a.RecommendationDetails.FalsePositiveReason,
-										ImpactScore:           *a.RecommendationDetails.ImpactScore,
-										ImpactDescription:     *a.RecommendationDetails.ImpactDescription,
-										WorkaroundAvailable:   *a.RecommendationDetails.WorkaroundAvailable,
+										ImpactScore:           a.RecommendationDetails.ImpactScore,
+										ImpactDescription:     a.RecommendationDetails.ImpactDescription,
+										WorkaroundAvailable:   a.RecommendationDetails.WorkaroundAvailable,
 										WorkaroundDescription: a.RecommendationDetails.WorkaroundDescription,
 									}
 									v.RecommendationDetails = &r


### PR DESCRIPTION
The generated `RecommendationDetails` fields handled nullable values (e.g. "impact_score"), but we later tried to de-reference them in our code even though our custom `RecommendationDetails` fields weren't pointers. 

### Before

```
bin/tidelift-sbom-vulnerability-reporter cyclonedx.json | jq
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10224ea4c]

goroutine 1 [running]:
main.writeVulnerabilitiesReport({0x0, 0x0}, {0x1400021dad0?, 0x102250235?, 0x6?}, {0x140002caa00, 0x2, 0x10200db28?})
        /Users/tiegzaharia/Code/sbom-to-api-tools/cmd/tidelift-sbom-vulnerability-reporter/main.go:147 +0xcfc
main.main()
        /Users/tiegzaharia/Code/sbom-to-api-tools/cmd/tidelift-sbom-vulnerability-reporter/main.go:87 +0x37c
```

### After

```
>  bin/tidelift-sbom-vulnerability-reporter cyclonedx.json | jq 
[
  {
    "vulnerability_id": "CVE-2021-33430",
    "nist_url": "https://nvd.nist.gov/vuln/detail/CVE-2021-33430",
    "cvss_score": "5.3",
    "platform": "pypi",
    "name": "numpy",
    "version": "0.9.8",
    "purl": "pkg:pypi/numpy@0.9.8",
    "recommendation": "ignore",
    "recommendation_details": {
      "real_issue": false,
      "false_positive_reason": "The NOTE in the disputed description is correct. There is no escalation of privileges. Furthermore (as explained in https://numpy.org/devdocs/reference/security.html#numpy-security), a user who can freely execute NumPy (or Python) functions must be considered to have the same privilege as the process/Python interpreter.\n\nPython as a whole and numerical libraries like NumPy are not designed to be exposed to untrusted users without sandboxing, and letting them run arbitrary Python/NumPy code.",
      "impact_score": null,
      "impact_description": null,
      "workaround_available": false,
      "workaround_description": null
    }
  },
```