### PR TITLE
Update cyclonedx-go to v0.9.0 for CycloneDX 1.6 support.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/tidelift/tidelift-sbom-info
 
 go 1.22
 
-require github.com/CycloneDX/cyclonedx-go v0.8.0 // direct
+require github.com/CycloneDX/cyclonedx-go v0.9.0 // direct
 
 require github.com/carlmjohnson/requests v0.23.5 // direct
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/CycloneDX/cyclonedx-go v0.8.0 h1:FyWVj6x6hoJrui5uRQdYZcSievw3Z32Z88uYzG/0D6M=
 github.com/CycloneDX/cyclonedx-go v0.8.0/go.mod h1:K2bA+324+Og0X84fA8HhN2X066K7Bxz4rpMQ4ZhjtSk=
+github.com/CycloneDX/cyclonedx-go v0.9.0 h1:inaif7qD8bivyxp7XLgxUYtOXWtDez7+j72qKTMQTb8=
+github.com/CycloneDX/cyclonedx-go v0.9.0/go.mod h1:NE/EWvzELOFlG6+ljX/QeMlVt9VKcTwu8u0ccsACEsw=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=


### PR DESCRIPTION
* updates `cyclonedx-go` [from v0.8.0 to v0.9.0](https://github.com/CycloneDX/cyclonedx-go/compare/v0.8.0...v0.9.0/)

this library added support for CycloneDX 1.6 in v0.9.0 (https://github.com/CycloneDX/cyclonedx-go/commit/729c284798ebe341ced210b661362f77d68cd655#diff-63dc80138e43e60e6f5e38641a6a4bc480151b0a3a38b5b9ae749cce1f49e17cR127-R130), so this fixes the following error when parsing 1.6 files:

```
> bin/tidelift-sbom-vulnerability-reporter cyclonedx_1_6.json
FATA[0000] Error: invalid specification version  
```
