### PR TITLE
Set initial values for some objects so we default to [] instead of null.

### DIFF
--- a/cmd/tidelift-sbom-vulnerability-reporter/main.go
+++ b/cmd/tidelift-sbom-vulnerability-reporter/main.go
@@ -90,7 +90,7 @@ func main() {
 }
 
 func writeVulnerabilitiesReport(outputFile string, purls []packageurl.PackageURL, releaseInfo []api.ReleaseDetail) error {
-	var vulnerabilties []VulnerabilityDetails
+	vulnerabilties := []VulnerabilityDetails{}
 
 	for _, purl := range purls {
 		releasePurlString := purl.ToString()

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -30,8 +30,8 @@ type releaseLookupResponse struct {
 }
 
 func GetPackageInfo(purls []packageurl.PackageURL) ([]api.PackageDetail, []api.Package) {
-	var packageInfo []api.PackageDetail
-	var missingPackages []api.Package
+	packageInfo := []api.PackageDetail{}
+	missingPackages := []api.Package{}
 
 	for start := 0; start < len(purls); start += CHUNK_SIZE {
 		purlStrings := chunkOfPurlStrings(purls, start, CHUNK_SIZE)
@@ -54,8 +54,9 @@ func GetPackageInfo(purls []packageurl.PackageURL) ([]api.PackageDetail, []api.P
 }
 
 func GetReleaseInfo(purls []packageurl.PackageURL) ([]api.ReleaseDetail, []PackageRelease) {
-	var releaseInfo []api.ReleaseDetail
-	var missingReleases []PackageRelease
+	releaseInfo := []api.ReleaseDetail{}
+	missingReleases := []PackageRelease{}
+
 	for start := 0; start < len(purls); start += CHUNK_SIZE {
 		purlStrings := chunkOfPurlStrings(purls, start, CHUNK_SIZE)
 


### PR DESCRIPTION
if no CVEs are reported for an SBOM using `tidelift-sbom-vulnerability-reporter`, it outputs `null` as the output. This initializes some variables after we declare them so we'll output `[]` instead.