### PR TITLE
Add a "-version" flag to both binaries, via goreleaser ldflags.

### DIFF
--- a/cmd/tidelift-sbom-analyzer/main.go
+++ b/cmd/tidelift-sbom-analyzer/main.go
@@ -15,11 +15,19 @@ import (
 	utils "github.com/tidelift/tidelift-sbom-info/internal/utils"
 )
 
+// This gets overwritten by goreleaser with the git tag, during a release.
+var (
+	version = "dev"
+)
+
 func main() {
 	var debug bool
 	var outputFile string
+	var printVersion bool
+
 	flag.BoolVar(&debug, "debug", false, "Show debug logging")
 	flag.StringVar(&outputFile, "output", "", "Write output to a file (defaults to stdout)")
+	flag.BoolVar(&printVersion, "version", false, "Show version information")
 
 	flag.Usage = func() {
 		fmt.Fprintln(flag.CommandLine.Output(), "Display a CSV containing recommendations from Tidelift for the packages in an SBOM.")
@@ -32,6 +40,11 @@ func main() {
 	}
 
 	flag.Parse()
+
+	if printVersion {
+		fmt.Println(version)
+		os.Exit(1)
+	}
 
 	if _, keyExists := os.LookupEnv("TIDELIFT_API_KEY"); !keyExists {
 		log.Fatalf("Error: TIDELIFT_API_KEY environment variable is required.")

--- a/cmd/tidelift-sbom-analyzer/main.go
+++ b/cmd/tidelift-sbom-analyzer/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	if printVersion {
 		fmt.Println(version)
-		os.Exit(1)
+		os.Exit(0)
 	}
 
 	if _, keyExists := os.LookupEnv("TIDELIFT_API_KEY"); !keyExists {

--- a/cmd/tidelift-sbom-vulnerability-reporter/main.go
+++ b/cmd/tidelift-sbom-vulnerability-reporter/main.go
@@ -66,7 +66,7 @@ func main() {
 
 	if printVersion {
 		fmt.Println(version)
-		os.Exit(1)
+		os.Exit(0)
 	}
 
 	if _, keyExists := os.LookupEnv("TIDELIFT_API_KEY"); !keyExists {

--- a/cmd/tidelift-sbom-vulnerability-reporter/main.go
+++ b/cmd/tidelift-sbom-vulnerability-reporter/main.go
@@ -38,7 +38,16 @@ type VulnerabilityDetails struct {
 	RecommendationDetails *RecommendationDetails `json:"recommendation_details"`
 }
 
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
+
+	fmt.Printf("my app %s, commit %s, built at %s", version, commit, date)
+
 	var debug bool
 	var outputFile string
 

--- a/cmd/tidelift-sbom-vulnerability-reporter/main.go
+++ b/cmd/tidelift-sbom-vulnerability-reporter/main.go
@@ -38,21 +38,19 @@ type VulnerabilityDetails struct {
 	RecommendationDetails *RecommendationDetails `json:"recommendation_details"`
 }
 
+// This gets overwritten by goreleaser with the git tag, during a release.
 var (
 	version = "dev"
-	commit  = "none"
-	date    = "unknown"
 )
 
 func main() {
-
-	fmt.Printf("my app %s, commit %s, built at %s", version, commit, date)
-
 	var debug bool
 	var outputFile string
+	var printVersion bool
 
 	flag.BoolVar(&debug, "debug", false, "Show debug logging")
 	flag.StringVar(&outputFile, "output", "", "Write output to a file (defaults to stdout)")
+	flag.BoolVar(&printVersion, "version", false, "Show version information")
 
 	flag.Usage = func() {
 		fmt.Fprintln(flag.CommandLine.Output(), "Display a JSON file containing vulnerabilities from Tidelift for the packages in an SBOM.")
@@ -65,6 +63,11 @@ func main() {
 	}
 
 	flag.Parse()
+
+	if printVersion {
+		fmt.Println(version)
+		os.Exit(1)
+	}
 
 	if _, keyExists := os.LookupEnv("TIDELIFT_API_KEY"); !keyExists {
 		log.Fatalf("Error: TIDELIFT_API_KEY environment variable is required.")


### PR DESCRIPTION
[goreleaser](https://goreleaser.com/cookbooks/using-main.version/) sets some build information on build, which we can use to implement a `-version` flag. 

testing on my branch artifacts:

```
> ./tidelift-sbom-vulnerability-reporter -version
0.0.0-tieg2
> ./tidelift-sbom-analyzer -version
0.0.0-tieg2
```

(we can also grab `commit` and `date` if we want)