### PR TITLE
De-dupe release PURLs after reading them.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tidelift/tidelift-sbom-info
 
-go 1.22
+go 1.23
 
 require github.com/CycloneDX/cyclonedx-go v0.9.0 // direct
 

--- a/internal/cyclonedx/cyclonedx.go
+++ b/internal/cyclonedx/cyclonedx.go
@@ -43,7 +43,7 @@ func decodeCyclonedx(filename string) (*cdx.BOM, error) {
 }
 
 func extractSupportedPurls(bom *cdx.BOM) ([]packageurl.PackageURL, error) {
-	var purls []packageurl.PackageURL
+	purlMap := map[string]packageurl.PackageURL{}
 
 	if bom.Components == nil {
 		log.Warn("CycloneDX file does not have any components")
@@ -70,10 +70,17 @@ func extractSupportedPurls(bom *cdx.BOM) ([]packageurl.PackageURL, error) {
 			continue
 		}
 
+		purlMap[purl.String()] = purl
+	}
+
+	purls := make([]packageurl.PackageURL, 0, len(purlMap))
+
+	for _, purl := range purlMap {
 		purls = append(purls, purl)
 	}
 
 	log.Debug(fmt.Sprintf("Found %d purls\n", len(purls)))
+
 	return purls, nil
 }
 


### PR DESCRIPTION
this should avoid waste during the Release lookup stage as well as the downloaded vuln report.

### Demo using a big SBOM containing duplicates

#### Before

```
DEBU[0000] Found 590 purls                              
DEBU[0009] Getting vulnerability info for CVE-2024-21742 
DEBU[0009] Getting vulnerability info for CVE-2024-29857 
DEBU[0009] Getting vulnerability info for CVE-2024-34447 
DEBU[0009] Getting vulnerability info for CVE-2024-30172 
DEBU[0010] Getting vulnerability info for CVE-2024-29857 
DEBU[0010] Getting vulnerability info for CVE-2024-30171 
DEBU[0010] Getting vulnerability info for CVE-2024-26308 
DEBU[0010] Getting vulnerability info for CVE-2024-25710 
DEBU[0011] Getting vulnerability info for CVE-2024-23450 
DEBU[0011] Getting vulnerability info for CVE-2024-23451 
DEBU[0011] Getting vulnerability info for CVE-2024-23444 
DEBU[0011] Getting vulnerability info for CVE-2024-3651 
DEBU[0012] Getting vulnerability info for CVE-2023-35116 
DEBU[0012] Getting vulnerability info for CVE-2023-35116 
DEBU[0012] Getting vulnerability info for CVE-2023-35116 
DEBU[0012] Getting vulnerability info for CVE-2023-35116 
DEBU[0012] Getting vulnerability info for CVE-2023-35116 
DEBU[0013] Getting vulnerability info for CVE-2023-35116 
DEBU[0013] Getting vulnerability info for CVE-2023-35116 
DEBU[0013] Getting vulnerability info for CVE-2023-35116 
DEBU[0013] Getting vulnerability info for CVE-2023-35116 
DEBU[0013] Getting vulnerability info for CVE-2023-35116 
DEBU[0014] Getting vulnerability info for CVE-2023-1370 
DEBU[0014] Getting vulnerability info for CVE-2020-9488 
DEBU[0014] Getting vulnerability info for CVE-2024-29025 
DEBU[0014] Getting vulnerability info for CVE-2024-29025 
DEBU[0015] Getting vulnerability info for CVE-2024-29025 
DEBU[0015] Getting vulnerability info for CVE-2024-29025 
DEBU[0015] Getting vulnerability info for CVE-2024-29025 
DEBU[0015] Getting vulnerability info for CVE-2024-29025 
DEBU[0016] Getting vulnerability info for CVE-2024-29025 
DEBU[0016] Getting vulnerability info for CVE-2024-29025 
DEBU[0016] Getting vulnerability info for CVE-2024-29025 
DEBU[0016] Getting vulnerability info for CVE-2023-4586 
DEBU[0017] Getting vulnerability info for CVE-2023-4586 
DEBU[0017] Getting vulnerability info for CVE-2023-4586 
DEBU[0017] Getting vulnerability info for CVE-2023-4586 
DEBU[0017] Getting vulnerability info for CVE-2023-4586 
DEBU[0017] Getting vulnerability info for CVE-2023-4586 
DEBU[0018] Getting vulnerability info for CVE-2023-4586 
DEBU[0018] Getting vulnerability info for CVE-2023-4586 
DEBU[0018] Getting vulnerability info for CVE-2023-4586 
DEBU[0018] Getting vulnerability info for CVE-2023-52428 
DEBU[0019] Getting vulnerability info for CVE-2023-34062 
DEBU[0019] Getting vulnerability info for CVE-2023-32681 
DEBU[0019] Getting vulnerability info for CVE-2024-35195 
DEBU[0019] Getting vulnerability info for CVE-2022-40897 
DEBU[0019] Getting vulnerability info for CVE-2024-6345 
DEBU[0020] Getting vulnerability info for CVE-2024-23081 
DEBU[0020] Getting vulnerability info for CVE-2024-23082 
DEBU[0020] Getting vulnerability info for CVE-2023-45803 
DEBU[0020] Getting vulnerability info for CVE-2024-37891 
DEBU[0021] Getting vulnerability info for CVE-2023-43804 
```

#### After

```
DEBU[0000] Found 462 purls                              
DEBU[0012] Getting vulnerability info for CVE-2023-35116 
DEBU[0012] Getting vulnerability info for CVE-2022-40897 
DEBU[0012] Getting vulnerability info for CVE-2024-6345 
DEBU[0012] Getting vulnerability info for CVE-2023-35116 
DEBU[0013] Getting vulnerability info for CVE-2023-32681 
DEBU[0013] Getting vulnerability info for CVE-2024-35195 
DEBU[0013] Getting vulnerability info for CVE-2023-34062 
DEBU[0013] Getting vulnerability info for CVE-2024-29025 
DEBU[0014] Getting vulnerability info for CVE-2023-52428 
DEBU[0014] Getting vulnerability info for CVE-2023-4586 
DEBU[0014] Getting vulnerability info for CVE-2024-21742 
DEBU[0015] Getting vulnerability info for CVE-2024-34447 
DEBU[0016] Getting vulnerability info for CVE-2024-30172 
DEBU[0016] Getting vulnerability info for CVE-2024-29857 
DEBU[0017] Getting vulnerability info for CVE-2024-30171 
DEBU[0017] Getting vulnerability info for CVE-2024-23450 
DEBU[0017] Getting vulnerability info for CVE-2024-23451 
DEBU[0018] Getting vulnerability info for CVE-2024-23444 
DEBU[0018] Getting vulnerability info for CVE-2023-1370 
DEBU[0018] Getting vulnerability info for CVE-2024-3651 
DEBU[0018] Getting vulnerability info for CVE-2020-9488 
DEBU[0019] Getting vulnerability info for CVE-2024-29857 
DEBU[0019] Getting vulnerability info for CVE-2024-26308 
DEBU[0019] Getting vulnerability info for CVE-2024-25710 
DEBU[0020] Getting vulnerability info for CVE-2024-23081 
DEBU[0020] Getting vulnerability info for CVE-2024-23082 
DEBU[0020] Getting vulnerability info for CVE-2023-45803 
DEBU[0020] Getting vulnerability info for CVE-2024-37891 
DEBU[0021] Getting vulnerability info for CVE-2023-43804 
```