### PR TITLE
Update go to 1.23.0 in goreleaser config too

### DIFF
--- a/.github/workflows/.goreleaser.yml
+++ b/.github/workflows/.goreleaser.yml
@@ -21,7 +21,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
-            go-version: '1.22.3'
+            go-version: '1.23.0'
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5


### PR DESCRIPTION
forgot to do this in https://github.com/tidelift/sbom-to-api-tools/pull/9 when I updated Go: https://github.com/tidelift/sbom-to-api-tools/actions/runs/10685256238